### PR TITLE
Bump pem and derp version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derp"
-version = "0.0.10"
+version = "0.0.11"
 authors = ["heartsucker <heartsucker@autistici.org>"]
 description = "DER Parser (and Writer)"
 homepage = "https://github.com/heartsucker/derp"
@@ -22,5 +22,5 @@ cli = [ "clap", "data-encoding", "pem" ]
 [dependencies]
 clap = { version = "2.23", optional = true }
 data-encoding = { version = "2.0.0-rc.1", optional = true }
-pem = { version = "0.4", optional = true }
+pem = { version = "0.5", optional = true }
 untrusted = "0.6"


### PR DESCRIPTION
If accepted, can you also publish a new version of derp? This will
allow rust-tuf to have it's ring version bumped.