### PR TITLE
Update to untrusted 0.7, pem 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derp"
-version = "0.0.11"
+version = "0.0.12"
 authors = ["heartsucker <heartsucker@autistici.org>"]
 description = "DER Parser (and Writer)"
 homepage = "https://github.com/heartsucker/derp"
@@ -23,4 +23,4 @@ cli = [ "clap", "data-encoding", "pem" ]
 clap = { version = "2.23", optional = true }
 data-encoding = { version = "2.0.0-rc.1", optional = true }
 pem = { version = "0.6", optional = true }
-untrusted = "0.6"
+untrusted = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,5 @@ cli = [ "clap", "data-encoding", "pem" ]
 [dependencies]
 clap = { version = "2.23", optional = true }
 data-encoding = { version = "2.0.0-rc.1", optional = true }
-pem = { version = "0.5", optional = true }
+pem = { version = "0.6", optional = true }
 untrusted = "0.6"

--- a/src/der.rs
+++ b/src/der.rs
@@ -45,6 +45,18 @@ pub enum Tag {
     ContextSpecificConstructed3 = CONTEXT_SPECIFIC | CONSTRUCTED | 3,
 }
 
+impl From<Tag> for usize {
+    fn from(tag: Tag) -> Self {
+        tag as Self
+    }
+}
+
+impl From<Tag> for u8 {
+    fn from(tag: Tag) -> Self {
+        tag as Self
+    } // XXX: narrowing conversion.
+}
+
 #[cfg(feature = "cli")]
 impl Display for Tag {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -64,7 +76,7 @@ impl Display for Tag {
             Tag::ContextSpecificConstructed2 => "CONTEXT SPECIFIC CONSTRUCTED 2",
             Tag::ContextSpecificConstructed3 => "CONTEXT SPECIFIC CONSTRUCTED 3",
         };
-        write!(f, "{}", s)
+        f.write_str(s)
     }
 }
 
@@ -102,7 +114,7 @@ impl Tag {
 /// Read a tag and return it's value. Errors when the expect and actual tag do not match.
 pub fn expect_tag_and_get_value<'a>(input: &mut Reader<'a>, tag: Tag) -> Result<Input<'a>> {
     let (actual_tag, inner) = read_tag_and_get_value(input)?;
-    if tag as u8 != actual_tag {
+    if usize::from(tag) != usize::from(actual_tag) {
         return Err(Error::WrongTag);
     }
     Ok(inner)
@@ -119,17 +131,17 @@ pub fn read_tag_and_get_value<'a>(input: &mut Reader<'a>) -> Result<(u8, Input<'
     // is encoded in the seven remaining bits of that byte. Otherwise, those
     // seven bits represent the number of bytes used to encode the length.
     let length = match input.read_byte()? {
-        n if (n & 0x80) == 0 => n as usize,
+        n if (n & 0x80) == 0 => usize::from(n),
         0x81 => {
             let second_byte = input.read_byte()?;
             if second_byte < 128 {
                 return Err(Error::NonCanonical);
             }
-            second_byte as usize
+            usize::from(second_byte)
         }
         0x82 => {
-            let second_byte = input.read_byte()? as usize;
-            let third_byte = input.read_byte()? as usize;
+            let second_byte = usize::from(input.read_byte()?);
+            let third_byte = usize::from(input.read_byte()?);
             let combined = (second_byte << 8) | third_byte;
             if combined < 256 {
                 return Err(Error::NonCanonical);
@@ -139,7 +151,7 @@ pub fn read_tag_and_get_value<'a>(input: &mut Reader<'a>) -> Result<(u8, Input<'
         _ => return Err(Error::LongLengthNotSupported),
     };
 
-    let inner = input.skip_and_get_input(length)?;
+    let inner = input.read_bytes(length)?;
     Ok((tag, inner))
 }
 
@@ -171,7 +183,7 @@ pub fn bit_string_with_no_unused_bits<'a>(input: &mut Reader<'a>) -> Result<Inpu
         if unused_bits_at_end != 0 {
             return Err(Error::NonZeroUnusedBits);
         }
-        Ok(value.skip_to_end())
+        Ok(value.read_bytes_to_end())
     })
 }
 
@@ -214,7 +226,7 @@ pub fn bit_string_with_no_unused_bits<'a>(input: &mut Reader<'a>) -> Result<Inpu
 // size.
 pub fn nested<'a, F, R>(input: &mut Reader<'a>, tag: Tag, decoder: F) -> Result<R>
 where
-    F: FnOnce(&mut Reader<'a>) -> Result<R>,
+    F: FnOnce(&mut untrusted::Reader<'a>) -> Result<R>,
 {
     let inner = expect_tag_and_get_value(input, tag)?;
     inner.read_all(Error::Read, decoder)
@@ -224,7 +236,7 @@ where
 pub fn nonnegative_integer<'a>(input: &mut Reader<'a>, min_value: u8) -> Result<Input<'a>> {
     // Verify that |input|, which has had any leading zero stripped off, is the
     // encoding of a value of at least |min_value|.
-    fn check_minimum(input: Input, min_value: u8) -> Result<()> {
+    fn check_minimum(input: untrusted::Input, min_value: u8) -> Result<()> {
         input.read_all(Error::Read, |input| {
             let first_byte = input.read_byte()?;
             if input.at_end() && first_byte < min_value {
@@ -250,7 +262,7 @@ pub fn nonnegative_integer<'a>(input: &mut Reader<'a>, min_value: u8) -> Result<
                 return Ok(value);
             }
 
-            let r = input.skip_to_end();
+            let r = input.read_bytes_to_end();
             r.read_all(Error::Read, |input| {
                 let second_byte = input.read_byte()?;
                 if (second_byte & 0x80) == 0 {
@@ -270,7 +282,7 @@ pub fn nonnegative_integer<'a>(input: &mut Reader<'a>, min_value: u8) -> Result<
             return Err(Error::NegativeValue);
         }
 
-        let _ = input.skip_to_end();
+        let _ = input.read_bytes_to_end();
         check_minimum(value, min_value)?;
         Ok(value)
     })
@@ -279,7 +291,7 @@ pub fn nonnegative_integer<'a>(input: &mut Reader<'a>, min_value: u8) -> Result<
 /// Parse as integer with a value in the in the range [0, 255], returning its
 /// numeric value. This is typically used for parsing version numbers.
 #[inline]
-pub fn small_nonnegative_integer(input: &mut Reader) -> Result<u8> {
+pub fn small_nonnegative_integer(input: &mut untrusted::Reader) -> Result<u8> {
     let value = nonnegative_integer(input, 0)?;
     value.read_all(Error::Read, |input| {
         let r = input.read_byte()?;
@@ -324,23 +336,23 @@ mod tests {
 
     fn with_good_i<F, R>(value: &[u8], f: F)
     where
-        F: FnOnce(&mut Reader) -> Result<R>,
+        F: FnOnce(&mut untrusted::Reader) -> Result<R>,
     {
-        let r = Input::from(value).read_all(Error::Read, f);
+        let r = untrusted::Input::from(value).read_all(Error::Read, f);
         assert!(r.is_ok());
     }
 
     fn with_bad_i<F, R>(value: &[u8], f: F)
     where
-        F: FnOnce(&mut Reader) -> Result<R>,
+        F: FnOnce(&mut untrusted::Reader) -> Result<R>,
     {
-        let r = Input::from(value).read_all(Error::Read, f);
+        let r = untrusted::Input::from(value).read_all(Error::Read, f);
         assert!(r.is_err());
     }
 
-    static ZERO_INTEGER: &'static [u8] = &[0x02, 0x01, 0x00];
+    static ZERO_INTEGER: &[u8] = &[0x02, 0x01, 0x00];
 
-    static GOOD_POSITIVE_INTEGERS: &'static [(&'static [u8], u8)] = &[
+    static GOOD_POSITIVE_INTEGERS: &[(&[u8], u8)] = &[
         (&[0x02, 0x01, 0x01], 0x01),
         (&[0x02, 0x01, 0x02], 0x02),
         (&[0x02, 0x01, 0x7e], 0x7e),
@@ -353,7 +365,7 @@ mod tests {
         (&[0x02, 0x02, 0x00, 0xff], 0xff),
     ];
 
-    static BAD_NONNEGATIVE_INTEGERS: &'static [&'static [u8]] = &[
+    static BAD_NONNEGATIVE_INTEGERS: &[&[u8]] = &[
         &[],           // At end of input
         &[0x02],       // Tag only
         &[0x02, 0x00], // Empty value
@@ -381,7 +393,7 @@ mod tests {
             assert_eq!(small_nonnegative_integer(input)?, 0x00);
             Ok(())
         });
-        for &(ref test_in, test_out) in GOOD_POSITIVE_INTEGERS.iter() {
+        for &(test_in, test_out) in GOOD_POSITIVE_INTEGERS.iter() {
             with_good_i(test_in, |input| {
                 assert_eq!(small_nonnegative_integer(input)?, test_out);
                 Ok(())
@@ -401,7 +413,7 @@ mod tests {
             let _ = positive_integer(input)?;
             Ok(())
         });
-        for &(ref test_in, test_out) in GOOD_POSITIVE_INTEGERS.iter() {
+        for &(test_in, test_out) in GOOD_POSITIVE_INTEGERS.iter() {
             with_good_i(test_in, |input| {
                 let test_out = [test_out];
                 assert_eq!(positive_integer(input)?, Input::from(&test_out[..]));


### PR DESCRIPTION
This updates derp to work with the latest untrusted and pem module. It also copies over some nice patterns from the latest ring der parser, that uses From<Tag> for usize/u8 to protect against silently truncating bytes.

If accepted, could a new version of derp be cut so it can be used in rust-tuf?