### PR TITLE
Update to untrusted 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ license = "ISC"
 keywords = [ "der", "parser" ]
 
 [dependencies]
-untrusted = "0.7"
+untrusted = "0.9"

--- a/src/der.rs
+++ b/src/der.rs
@@ -174,7 +174,7 @@ pub fn read_null<'a>(input: &mut Reader<'a>) -> Result<()> {
 ///     let bits = input.read_all(derp::Error::Read, |input| {
 ///         derp::bit_string_with_no_unused_bits(input)
 ///     }).unwrap();
-///     assert_eq!(bits, Input::from(&[0x01, 0x02, 0x03]));
+///     assert_eq!(bits.as_slice_less_safe(), &[0x01, 0x02, 0x03]);
 /// }
 /// ```
 pub fn bit_string_with_no_unused_bits<'a>(input: &mut Reader<'a>) -> Result<Input<'a>> {
@@ -217,9 +217,9 @@ pub fn bit_string_with_no_unused_bits<'a>(input: &mut Reader<'a>) -> Result<Inpu
 ///         })
 ///     }).unwrap();
 ///
-///     assert_eq!(x, Input::from(&[0x0a, 0x0b, 0x0c, 0x0d]));
-///     assert_eq!(y, Input::from(&[0x1a, 0x1b, 0x1c, 0x1d]));
-///     assert_eq!(z, Input::from(&[0x01, 0x02, 0x03, 0x04]));
+///     assert_eq!(x.as_slice_less_safe(), &[0x0a, 0x0b, 0x0c, 0x0d]);
+///     assert_eq!(y.as_slice_less_safe(), &[0x1a, 0x1b, 0x1c, 0x1d]);
+///     assert_eq!(z.as_slice_less_safe(), &[0x01, 0x02, 0x03, 0x04]);
 /// }
 /// ```
 // TODO: investigate taking decoder as a reference to reduce generated code
@@ -416,7 +416,7 @@ mod tests {
         for &(test_in, test_out) in GOOD_POSITIVE_INTEGERS.iter() {
             with_good_i(test_in, |input| {
                 let test_out = [test_out];
-                assert_eq!(positive_integer(input)?, Input::from(&test_out[..]));
+                assert_eq!(positive_integer(input)?.as_slice_less_safe(), test_out);
                 Ok(())
             });
         }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
-use crate::Result;
 use crate::der::{self, Tag};
+use crate::Result;
 
 /// Helper for writing DER that automattically encoes tags and content lengths.
 pub struct Der<'a, W: Write + 'a> {
@@ -11,7 +11,7 @@ pub struct Der<'a, W: Write + 'a> {
 impl<'a, W: Write> Der<'a, W> {
     /// Create a new `Der` structure that writes values to the given writer.
     pub fn new(writer: &'a mut W) -> Self {
-        Der { writer: writer }
+        Der { writer }
     }
 
     fn write_len(&mut self, len: usize) -> Result<()> {
@@ -130,8 +130,8 @@ impl<'a, W: Write> Der<'a, W> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use untrusted::Input;
     use crate::Error;
+    use untrusted::Input;
 
     static RSA_2048_PKCS1: &'static [u8] = include_bytes!("../tests/rsa-2048.pkcs1.der");
 


### PR DESCRIPTION
Reformat the code using `cargo fmt` from Rust Toolchain 1.74.1. Then update to the latest version of untrusted 0.9, which is used by the latest version of *ring*. This allows projects that use *ring* 0.17 to have only a single copy of untrusted.